### PR TITLE
adding dash as valid identifier character

### DIFF
--- a/lib/ruby-handlebars/parser.rb
+++ b/lib/ruby-handlebars/parser.rb
@@ -17,7 +17,7 @@ module Handlebars
     rule(:tccurly)     { ccurly >> ccurly >> ccurly }
 
     rule(:else_kw)     { str('else') }
-    rule(:identifier)  { (else_kw >> space? >> dccurly).absent? >> match['@a-zA-Z0-9_\?'].repeat(1) }
+    rule(:identifier)  { (else_kw >> space? >> dccurly).absent? >> match['@\-a-zA-Z0-9_\?'].repeat(1) }
     rule(:path)        { identifier >> (dot >> identifier).repeat }
 
     rule(:nocurly)     { match('[^{}]') }

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -47,6 +47,10 @@ describe Handlebars::Handlebars do
       expect(evaluate('My simple template: {{person.name}}', {person: {name: 'Another name'}})).to eq('My simple template: Another name')
     end
 
+    it 'handles a parameter with a dash' do
+      expect(evaluate('Hello {{first-name}}', double("first-name": 'world'))).to eq('Hello world')
+    end
+
     context 'partials' do
       it 'simple' do
         hbs.register_partial('plic', "Plic")


### PR DESCRIPTION
Not sure if this is deceptively simple fix, but this allows identifier names to have a dash in them which is supported by handlebars.js.  

Spec added to handlebars_spec.rb