### PR TITLE
Add boolean helpers

### DIFF
--- a/lib/ruby-handlebars/helpers/default_helper.rb
+++ b/lib/ruby-handlebars/helpers/default_helper.rb
@@ -24,5 +24,20 @@ module Handlebars
       #   # Do things and stuffa, but with 'as |param| notation'
       # end
     end
+
+    class BooleanHelper < DefaultHelper
+      # Helper that simply return "true" or ""
+
+      def self.apply(context, item1, item2, block = nil, else_block = nil)
+        self.cmp(item1, item2) ? 'true' : ''
+      rescue Exception => err
+        ''
+      end
+
+      # To be implemented by sub-classes
+      # def self.cmp(item1, item2)
+      #   do a boolean comparison on item1 and item2
+      # end
+    end
   end
 end

--- a/lib/ruby-handlebars/helpers/eq_helper.rb
+++ b/lib/ruby-handlebars/helpers/eq_helper.rb
@@ -1,14 +1,14 @@
+require_relative 'default_helper'
+
 module Handlebars
   module Helpers
-    class EqHelper < DefaultHelper
+    class EqHelper < BooleanHelper
       def self.registry_name
         'eq'
       end
 
-      def self.apply(context, item1, item2, block = nil, else_block = nil)
-        item1 == item2 ? 'true' : ''
-      rescue Exception => err
-        ''
+      def self.cmp(item1, item2)
+        item1 == item2
       end
     end
   end

--- a/lib/ruby-handlebars/helpers/eq_helper.rb
+++ b/lib/ruby-handlebars/helpers/eq_helper.rb
@@ -1,0 +1,15 @@
+module Handlebars
+  module Helpers
+    class EqHelper < DefaultHelper
+      def self.registry_name
+        'eq'
+      end
+
+      def self.apply(context, item1, item2, block = nil, else_block = nil)
+        item1 == item2 ? 'true' : ''
+      rescue Exception => err
+        ''
+      end
+    end
+  end
+end

--- a/lib/ruby-handlebars/helpers/gt_helper.rb
+++ b/lib/ruby-handlebars/helpers/gt_helper.rb
@@ -1,0 +1,15 @@
+require_relative 'default_helper'
+
+module Handlebars
+  module Helpers
+    class GtHelper < BooleanHelper
+      def self.registry_name
+        'gt'
+      end
+
+      def self.cmp(item1, item2)
+        item1 > item2
+      end
+    end
+  end
+end

--- a/lib/ruby-handlebars/helpers/gte_helper.rb
+++ b/lib/ruby-handlebars/helpers/gte_helper.rb
@@ -1,0 +1,15 @@
+require_relative 'default_helper'
+
+module Handlebars
+  module Helpers
+    class GteHelper < BooleanHelper
+      def self.registry_name
+        'gte'
+      end
+
+      def self.cmp(item1, item2)
+        item1 >= item2
+      end
+    end
+  end
+end

--- a/lib/ruby-handlebars/helpers/register_default_helpers.rb
+++ b/lib/ruby-handlebars/helpers/register_default_helpers.rb
@@ -1,6 +1,7 @@
 require_relative 'each_helper'
 require_relative 'eq_helper'
 require_relative 'gt_helper'
+require_relative 'gte_helper'
 require_relative 'helper_missing_helper'
 require_relative 'if_helper'
 require_relative 'unless_helper'
@@ -11,6 +12,7 @@ module Handlebars
       EachHelper.register(hbs)
       EqHelper.register(hbs)
       GtHelper.register(hbs)
+      GteHelper.register(hbs)
       HelperMissingHelper.register(hbs)
       IfHelper.register(hbs)
       UnlessHelper.register(hbs)

--- a/lib/ruby-handlebars/helpers/register_default_helpers.rb
+++ b/lib/ruby-handlebars/helpers/register_default_helpers.rb
@@ -1,4 +1,5 @@
 require_relative 'each_helper'
+require_relative 'eq_helper'
 require_relative 'helper_missing_helper'
 require_relative 'if_helper'
 require_relative 'unless_helper'
@@ -7,6 +8,7 @@ module Handlebars
   module Helpers
     def self.register_default_helpers(hbs)
       EachHelper.register(hbs)
+      EqHelper.register(hbs)
       HelperMissingHelper.register(hbs)
       IfHelper.register(hbs)
       UnlessHelper.register(hbs)

--- a/lib/ruby-handlebars/helpers/register_default_helpers.rb
+++ b/lib/ruby-handlebars/helpers/register_default_helpers.rb
@@ -1,5 +1,6 @@
 require_relative 'each_helper'
 require_relative 'eq_helper'
+require_relative 'gt_helper'
 require_relative 'helper_missing_helper'
 require_relative 'if_helper'
 require_relative 'unless_helper'
@@ -9,6 +10,7 @@ module Handlebars
     def self.register_default_helpers(hbs)
       EachHelper.register(hbs)
       EqHelper.register(hbs)
+      GtHelper.register(hbs)
       HelperMissingHelper.register(hbs)
       IfHelper.register(hbs)
       UnlessHelper.register(hbs)

--- a/spec/ruby-handlebars/helpers/default_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/default_helper_spec.rb
@@ -1,0 +1,38 @@
+require_relative '../../spec_helper'
+require_relative './shared'
+
+require_relative '../../../lib/ruby-handlebars'
+require_relative '../../../lib/ruby-handlebars/helpers/default_helper'
+
+describe Handlebars::Helpers::BooleanHelper do
+  subject { Handlebars::Helpers::BooleanHelper }
+  let(:hbs) {Handlebars::Handlebars.new}
+
+  context '.apply' do
+    it 'simply forward values to .cmp' do
+      allow(subject).to receive(:cmp)
+      subject.apply(hbs, 1, 2)
+
+      expect(subject).to have_received(:cmp).once.with(1, 2)
+    end
+
+    it "returns 'true' (as a string) when cmp returns true" do
+      allow(subject).to receive(:cmp).and_return(true)
+
+      expect(subject.apply(hbs, 1, 2)).to eq('true')
+    end
+
+    it "returns an empty string when cmp returns false" do
+      allow(subject).to receive(:cmp).and_return(false)
+
+      expect(subject.apply(hbs, 1, 2)).to eq('')
+    end
+
+    it 'returns an empty string when cmp raises an exception' do
+      allow(subject).to receive(:cmp).and_raise("Whatever error")
+
+      expect(subject.apply(hbs, 1, 2)).to eq('')
+
+    end
+  end
+end

--- a/spec/ruby-handlebars/helpers/eq_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/eq_helper_spec.rb
@@ -25,16 +25,6 @@ describe Handlebars::Helpers::EqHelper do
       expect(subject.apply(hbs, 123, "456")).to eq('')
     end
 
-    it 'returns an empty string when comparison raises an exception' do
-      class BadStuff
-        def == second
-          raise "Nope !"
-        end
-      end
-
-      expect(subject.apply(hbs, BadStuff.new, "456")).to eq('')
-    end
-
     it 'not not takes the blocks into account' do
       subject.apply(hbs, 123, 123, block, else_block)
       subject.apply(hbs, 123, 456, block, else_block)

--- a/spec/ruby-handlebars/helpers/eq_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/eq_helper_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../spec_helper'
+require_relative './shared'
+
+require_relative '../../../lib/ruby-handlebars/helpers/eq_helper'
+
+
+describe Handlebars::Helpers::EqHelper do
+  let(:subject) { Handlebars::Helpers::EqHelper }
+  let(:hbs) {Handlebars::Handlebars.new}
+
+  it_behaves_like "a registerable helper", "eq"
+
+  context '.apply' do
+    include_context "shared apply helper"
+
+    it 'returns "true" when first value equals second one' do
+      expect(subject.apply(hbs, 1, 1)).to eq('true')
+    end
+
+    it 'returns an empty string when first value equals second one' do
+      expect(subject.apply(hbs, 1, 2)).to eq('')
+    end
+
+    it 'returns an empty string when values can not be compared' do
+      expect(subject.apply(hbs, 123, "456")).to eq('')
+    end
+
+    it 'returns an empty string when comparison raises an exception' do
+      class BadStuff
+        def == second
+          raise "Nope !"
+        end
+      end
+
+      expect(subject.apply(hbs, BadStuff.new, "456")).to eq('')
+    end
+
+    it 'not not takes the blocks into account' do
+      subject.apply(hbs, 123, 123, block, else_block)
+      subject.apply(hbs, 123, 456, block, else_block)
+
+      expect(block).not_to have_received(:fn)
+      expect(else_block).not_to have_received(:fn)
+    end
+  end
+
+  context 'integration' do
+    include_context "shared helpers integration tests"
+
+    it 'can be used as a condition for an #if helper' do
+      template = "{{#if (eq a b)}}Ok{{else}}Not ok ...{{/if}}"
+
+      expect(evaluate(template, {a: 1, b: 1})).to eq("Ok")
+      expect(evaluate(template, {a: 1, b: "1"})).to eq("Not ok ...")
+    end
+  end
+end

--- a/spec/ruby-handlebars/helpers/gt_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/gt_helper_spec.rb
@@ -1,0 +1,57 @@
+require_relative '../../spec_helper'
+require_relative './shared'
+
+require_relative '../../../lib/ruby-handlebars/helpers/gt_helper'
+
+
+describe Handlebars::Helpers::GtHelper do
+  let(:subject) { Handlebars::Helpers::GtHelper }
+  let(:hbs) {Handlebars::Handlebars.new}
+
+  it_behaves_like "a registerable helper", "gt"
+
+  context '.apply' do
+    include_context "shared apply helper"
+
+    it 'returns "true" when first value is greater than second one' do
+      expect(subject.apply(hbs, 2, 1)).to eq('true')
+    end
+
+    it 'returns an empty string when first value is greater than second one' do
+      expect(subject.apply(hbs, 1, 2)).to eq('')
+    end
+
+    it 'returns an empty string when values can not be compared' do
+      expect(subject.apply(hbs, 123, "456")).to eq('')
+    end
+
+    it 'returns an empty string when comparison raises an exception' do
+      class BadStuff
+        def > second
+          raise "Nope !"
+        end
+      end
+
+      expect(subject.apply(hbs, BadStuff.new, "456")).to eq('')
+    end
+
+    it 'not not takes the blocks into account' do
+      subject.apply(hbs, 123, 123, block, else_block)
+      subject.apply(hbs, 123, 456, block, else_block)
+
+      expect(block).not_to have_received(:fn)
+      expect(else_block).not_to have_received(:fn)
+    end
+  end
+
+  context 'integration' do
+    include_context "shared helpers integration tests"
+
+    it 'can be used as a condition for an #if helper' do
+      template = "{{#if (gt a b)}}Ok{{else}}Not ok ...{{/if}}"
+
+      expect(evaluate(template, {a: 2, b: 1})).to eq("Ok")
+      expect(evaluate(template, {a: 1, b: 1})).to eq("Not ok ...")
+    end
+  end
+end

--- a/spec/ruby-handlebars/helpers/gt_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/gt_helper_spec.rb
@@ -25,16 +25,6 @@ describe Handlebars::Helpers::GtHelper do
       expect(subject.apply(hbs, 123, "456")).to eq('')
     end
 
-    it 'returns an empty string when comparison raises an exception' do
-      class BadStuff
-        def > second
-          raise "Nope !"
-        end
-      end
-
-      expect(subject.apply(hbs, BadStuff.new, "456")).to eq('')
-    end
-
     it 'not not takes the blocks into account' do
       subject.apply(hbs, 123, 123, block, else_block)
       subject.apply(hbs, 123, 456, block, else_block)

--- a/spec/ruby-handlebars/helpers/gte_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/gte_helper_spec.rb
@@ -1,0 +1,47 @@
+require_relative '../../spec_helper'
+require_relative './shared'
+
+require_relative '../../../lib/ruby-handlebars/helpers/gte_helper'
+
+
+describe Handlebars::Helpers::GteHelper do
+  let(:subject) { Handlebars::Helpers::GteHelper }
+  let(:hbs) {Handlebars::Handlebars.new}
+
+  it_behaves_like "a registerable helper", "gte"
+
+  context '.apply' do
+    include_context "shared apply helper"
+
+    it 'returns "true" when first value is greater or equal than second one' do
+      expect(subject.apply(hbs, 1, 1)).to eq('true')
+    end
+
+    it 'returns an empty string when first value is greater or equal than second one' do
+      expect(subject.apply(hbs, 1, 2)).to eq('')
+    end
+
+    it 'returns an empty string when values can not be compared' do
+      expect(subject.apply(hbs, 123, "456")).to eq('')
+    end
+
+    it 'not not takes the blocks into account' do
+      subject.apply(hbs, 123, 123, block, else_block)
+      subject.apply(hbs, 123, 456, block, else_block)
+
+      expect(block).not_to have_received(:fn)
+      expect(else_block).not_to have_received(:fn)
+    end
+  end
+
+  context 'integration' do
+    include_context "shared helpers integration tests"
+
+    it 'can be used as a condition for an #if helper' do
+      template = "{{#if (gt a b)}}Ok{{else}}Not ok ...{{/if}}"
+
+      expect(evaluate(template, {a: 2, b: 1})).to eq("Ok")
+      expect(evaluate(template, {a: 0, b: 1})).to eq("Not ok ...")
+    end
+  end
+end


### PR DESCRIPTION
Basically, support simple boolean helpers to introduce a bit of logic in the templates.

 - [x] `eq` to compare equality between items
 - [ ] `includes` to check if item2 is included in item 1
 - [x] `gt` to check if item1 is greater than item1
 - [x] `gte` to check if item1 is greater than or equal to item1
 - [ ] `lt` to check if item1 is lesser than item1
 - [ ] `lte` to check if item1 is lesser than or equal to item1

The idea is to use those helpers inside other helpers (`if` or `unless`).

Example:
```
{{#if (eq name "John")}}
  Hello Johnny!
{{else}}
  {{name}}
{{/if}}
```