### PR TITLE
Basic support for the "with" template helper

### DIFF
--- a/lib/ruby-handlebars/helpers/register_default_helpers.rb
+++ b/lib/ruby-handlebars/helpers/register_default_helpers.rb
@@ -2,6 +2,7 @@ require_relative 'each_helper'
 require_relative 'helper_missing_helper'
 require_relative 'if_helper'
 require_relative 'unless_helper'
+require_relative 'with_helper'
 
 module Handlebars
   module Helpers
@@ -10,6 +11,7 @@ module Handlebars
       HelperMissingHelper.register(hbs)
       IfHelper.register(hbs)
       UnlessHelper.register(hbs)
+      WithHelper.register(hbs)
     end
   end
 end

--- a/lib/ruby-handlebars/helpers/with_helper.rb
+++ b/lib/ruby-handlebars/helpers/with_helper.rb
@@ -1,0 +1,25 @@
+require_relative 'default_helper'
+
+module Handlebars
+  module Helpers
+    class WithHelper < DefaultHelper
+      def self.registry_name
+        'with'
+      end
+
+      def self.apply(context, data, block, else_block)
+        if data
+          context.with_temporary_context(data) do
+            block.fn(context)
+          end
+        else
+          else_block.fn(context)
+        end
+      end
+
+      def self.apply_as(context, data, name, block, else_block)
+        self.apply(context, { name.to_sym => data }, block, else_block)
+      end
+    end
+  end
+end

--- a/spec/ruby-handlebars/helpers/with_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/with_helper_spec.rb
@@ -64,5 +64,17 @@ describe Handlebars::Helpers::WithHelper do
 
       expect(evaluate(template, person_data).strip).to eq("No city found")
     end
+
+    it "supports relative paths", skip: "Relative paths are not yet supported" do
+      template = <<~HANDLEBARS
+        {{#with city as | city |}}
+          {{#with city.location as | loc |}}
+            {{city.name}}: {{../population}}
+          {{/with}}
+        {{/with}}
+      HANDLEBARS
+
+      expect(evaluate(template, city_data).strip).to eq("San Francisco: 883305")
+    end
   end
 end

--- a/spec/ruby-handlebars/helpers/with_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/with_helper_spec.rb
@@ -1,0 +1,68 @@
+require_relative '../../spec_helper'
+require_relative './shared'
+
+require_relative '../../../lib/ruby-handlebars'
+require_relative '../../../lib/ruby-handlebars/tree'
+require_relative '../../../lib/ruby-handlebars/helpers/with_helper'
+
+describe Handlebars::Helpers::WithHelper do
+  let(:subject) { Handlebars::Helpers::WithHelper }
+  let(:hbs) { Handlebars::Handlebars.new }
+
+  it_behaves_like "a registerable helper", "with"
+
+  context '.apply' do
+    include_context "shared apply helper"
+  end
+
+  context "integration" do
+    include_context "shared helpers integration tests"
+
+    let(:person_data) { { person: { firstname: "Yehuda", lastname: "Katz" }} }
+    let(:city_data) { {
+      city: {
+        name: "San Francisco",
+        summary: "San Francisco is the <b>cultural center</b> of <b>Northern California</b>",
+        location: {
+          north: "37.73,",
+          east: -122.44,
+        },
+        population: 883305,
+      },
+    } }
+
+    it "changes the evaluation context" do
+      template = <<~HANDLEBARS
+        {{#with person}}
+        {{firstname}} {{lastname}}
+        {{/with}}
+      HANDLEBARS
+
+      expect(evaluate(template, person_data).strip).to eq("Yehuda Katz")
+    end
+
+    it "supports block parameters" do
+      template = <<~HANDLEBARS
+        {{#with city as | city |}}
+          {{#with city.location as | loc |}}
+            {{city.name}}: {{loc.north}} {{loc.east}}
+          {{/with}}
+        {{/with}}
+      HANDLEBARS
+
+      expect(evaluate(template, city_data).strip).to eq("San Francisco: 37.73, -122.44")
+    end
+
+    it "supports else blocks" do
+      template = <<~HANDLEBARS
+        {{#with city}}
+        {{city.name}} (not shown because there is no city)
+        {{else}}
+        No city found
+        {{/with}}
+      HANDLEBARS
+
+      expect(evaluate(template, person_data).strip).to eq("No city found")
+    end
+  end
+end


### PR DESCRIPTION
One of Handlebars' built-in helpers is [`{{with}}`](https://handlebarsjs.com/guide/builtin-helpers.html#with), which allows you to change "contexts" in a template. Basically, it makes it easier to use nested objects. As the [Handlebars documentation demonstrates](https://handlebarsjs.com/guide/builtin-helpers.html#with), given this data: 

```javascript
{ person: { firstname: "Yehuda", lastname: "Katz" } }
```

Then you can write this template to render "Yehuda Katz": 

```handlebars
{{#with person}}
{{firstname}} {{lastname}}
{{/with}}
```

This PR adds basic support for this helper, along with some test cases (taken from the Handlebars documentation) to demonstrate it works. 

--- 

One wrinkle with this PR: it doesn't support [relative paths](https://handlebarsjs.com/guide/expressions.html#changing-the-context), as that's not yet supported in ruby-handlebars. I've included a (skipped) test case that demonstrates this (which [works in the Handlebars playground](https://handlebarsjs.com/playground.html#format=1&currentExample=%7B%22template%22%3A%22%7B%7B%23with%20city%20as%20%7C%20city%20%7C%7D%7D%5Cn%20%20%7B%7B%23with%20city.location%20as%20%7C%20loc%20%7C%7D%7D%5Cn%20%20%20%20%7B%7Bcity.name%7D%7D%3A%20%7B%7B..%2Fpopulation%7D%7D%5Cn%20%20%7B%7B%2Fwith%7D%7D%5Cn%7B%7B%2Fwith%7D%7D%5Cn%22%2C%22partials%22%3A%5B%5D%2C%22input%22%3A%22%7B%5Cn%20%20city%3A%20%7B%5Cn%20%20%20%20name%3A%20%5C%22San%20Francisco%5C%22%2C%5Cn%20%20%20%20summary%3A%20%5C%22San%20Francisco%20is%20the%20%3Cb%3Ecultural%20center%3C%2Fb%3E%20of%20%3Cb%3ENorthern%20California%3C%2Fb%3E%5C%22%2C%5Cn%20%20%20%20location%3A%20%7B%5Cn%20%20%20%20%20%20north%3A%20%5C%2237.73%2C%5C%22%2C%5Cn%20%20%20%20%20%20east%3A%20-122.44%2C%5Cn%20%20%20%20%7D%2C%5Cn%20%20%20%20population%3A%20883305%2C%5Cn%20%20%7D%2C%5Cn%7D%5Cn%22%2C%22output%22%3A%22%20%20%20%20San%20Francisco%3A%20883305%5Cn%22%2C%22preparationScript%22%3A%22%2F%2F%20Handlebars.registerHelper('loud'%2C%20function(string)%20%7B%5Cn%2F%2F%20%20%20%20return%20string.toUpperCase()%5Cn%2F%2F%20%7D)%3B%5Cn%22%2C%22handlebarsVersion%22%3A%224.7.6%22%7D)), but I can't figure out how to add parser support for that. Some help here would be very welcome! I'd also like to add support for [`{{lookup}}`](https://handlebarsjs.com/guide/builtin-helpers.html#lookup), but getting relative paths to work is a prerequisite for that. 