### PR TITLE
Create separate context for each template evaluation

### DIFF
--- a/lib/ruby-handlebars.rb
+++ b/lib/ruby-handlebars.rb
@@ -7,7 +7,6 @@ require_relative 'ruby-handlebars/escapers/html_escaper'
 
 module Handlebars
   class Handlebars
-    include Context
     attr_reader :escaper
 
     def initialize()
@@ -44,10 +43,6 @@ module Handlebars
 
     def get_partial(name)
       @partials[name.to_s]
-    end
-
-    def set_context(ctx)
-      @data = ctx
     end
 
     def set_escaper(escaper = nil)

--- a/lib/ruby-handlebars/context.rb
+++ b/lib/ruby-handlebars/context.rb
@@ -1,5 +1,10 @@
 module Handlebars
-  module Context
+  class Context
+    def initialize(hbs, data)
+      @hbs = hbs
+      @data = data
+    end
+
     def get(path)
       items = path.split('.'.freeze)
       if locals.key? items.first.to_sym
@@ -13,6 +18,22 @@ module Handlebars
       end
 
       current
+    end
+
+    def escaper
+      @hbs.escaper
+    end
+
+    def get_helper(name)
+      @hbs.get_helper(name)
+    end
+
+    def get_as_helper(name)
+      @hbs.get_as_helper(name)
+    end
+
+    def get_partial(name)
+      @hbs.get_partial(name)
     end
 
     def add_item(key, value)

--- a/lib/ruby-handlebars/template.rb
+++ b/lib/ruby-handlebars/template.rb
@@ -8,11 +8,13 @@ module Handlebars
     end
 
     def call(args = nil)
-      if args
-        @hbs.set_context(args)
-      end
+      ctx = Context.new(@hbs, args)
 
-      @ast.eval(@hbs)
+      @ast.eval(ctx)
+    end
+
+    def call_with_context(ctx)
+      @ast.eval(ctx)
     end
   end
 end

--- a/lib/ruby-handlebars/tree.rb
+++ b/lib/ruby-handlebars/tree.rb
@@ -74,7 +74,7 @@ module Handlebars
 
     class Partial < TreeItem.new(:partial_name)
       def _eval(context)
-        context.get_partial(partial_name.to_s).call
+        context.get_partial(partial_name.to_s).call_with_context(context)
       end
     end
 
@@ -83,7 +83,7 @@ module Handlebars
         [arguments].flatten.map(&:values).map do |vals| 
           context.add_item vals.first.to_s, vals.last._eval(context)
         end
-        context.get_partial(partial_name.to_s).call
+        context.get_partial(partial_name.to_s).call_with_context(context)
       end
     end
 

--- a/spec/ruby-handlebars/context_spec.rb
+++ b/spec/ruby-handlebars/context_spec.rb
@@ -2,141 +2,143 @@ require_relative '../spec_helper'
 require_relative '../../lib/ruby-handlebars/context'
 
 describe Handlebars::Context do
-  include Handlebars::Context
+  let(:ctx) { described_class.new(nil, data) }
 
   context 'get' do
-    before do
-      @data = {
-        key_data: 'Some value'
-      }
+    let(:data) { {
+      key_data: 'Some value'
+    } }
 
-      @locals = {
-        key_locals: 'Some other value',
-        a_list: ['a', 'b', 'c'],
-        a_hash: {key: 'A third value'}
-      }
+    before do
+      ctx.add_item(:key_locals, 'Some other value')
+      ctx.add_item(:a_list, ['a', 'b', 'c'])
+      ctx.add_item(:a_hash, {key: 'A third value'})
     end
 
     it 'fetches data stored in the context' do
-      expect(get('key_data')).to eq('Some value')
-      expect(get('key_locals')).to eq('Some other value')
+      expect(ctx.get('key_data')).to eq('Some value')
+      expect(ctx.get('key_locals')).to eq('Some other value')
     end
 
     it 'uses data from @locals before @data' do
-      @locals[:key_data] = 'Now stored in @locals'
+      ctx.add_item(:key_data, 'Now stored in @locals')
 
-      expect(get('key_data')).to eq('Now stored in @locals')
+      expect(ctx.get('key_data')).to eq('Now stored in @locals')
     end
 
     context 'when digging inside data' do
       it 'uses keys separated by dots' do
-        expect(get('a_hash.key')).to eq('A third value')
+        expect(ctx.get('a_hash.key')).to eq('A third value')
       end
 
       it 'can also use methods' do
-        expect(get('a_list.first')).to eq('a')
-        expect(get('a_list.last')).to eq('c')
+        expect(ctx.get('a_list.first')).to eq('a')
+        expect(ctx.get('a_list.last')).to eq('c')
       end
     end
   end
 
   context 'add_item' do
+    let(:data) { {} }
+
     it 'adds a new key to the stored data' do
-      expect(get('my_key')).to be nil
-      add_item('my_key', 'With some value')
-      expect(get('my_key')).to eq('With some value')
+      expect(ctx.get('my_key')).to be nil
+      ctx.add_item('my_key', 'With some value')
+      expect(ctx.get('my_key')).to eq('With some value')
     end
 
     it 'overrides existing values' do
-      add_item('a', 12)
-      add_item('a', 25)
+      ctx.add_item('a', 12)
+      ctx.add_item('a', 25)
 
-      expect(get('a')).to eq(25)
+      expect(ctx.get('a')).to eq(25)
     end
 
     it 'does not make differences between string and sym keys' do
-      add_item('a', 12)
-      add_item(:a, 25)
+      ctx.add_item('a', 12)
+      ctx.add_item(:a, 25)
 
-      expect(get('a')).to eq(25)
+      expect(ctx.get('a')).to eq(25)
     end
   end
 
   context 'add_items' do
-    it 'is basically a wrapper around add_item to add multiple items' do
-      allow(self).to receive(:add_item)
+    let(:data) { {} }
 
-      add_items(a: 'One key', b: 'A second key', c: 'A third key')
-      expect(self).to have_received(:add_item).at_most(3).times
-      expect(self).to have_received(:add_item).once.with(:a, 'One key')
-      expect(self).to have_received(:add_item).once.with(:b, 'A second key')
-      expect(self).to have_received(:add_item).once.with(:c, 'A third key')
+    it 'is basically a wrapper around add_item to add multiple items' do
+      allow(ctx).to receive(:add_item)
+
+      ctx.add_items(a: 'One key', b: 'A second key', c: 'A third key')
+      expect(ctx).to have_received(:add_item).at_most(3).times
+      expect(ctx).to have_received(:add_item).once.with(:a, 'One key')
+      expect(ctx).to have_received(:add_item).once.with(:b, 'A second key')
+      expect(ctx).to have_received(:add_item).once.with(:c, 'A third key')
     end
   end
 
   context 'with_temporary_context' do
+    let(:data) { {} }
+
     before do
-      add_items(
+      ctx.add_items(
         key: 'some key',
         value: 'some value'
       )
     end
 
     it 'allows creating temporary variables' do
-      expect(get('unknown_key')).to be nil
+      expect(ctx.get('unknown_key')).to be nil
 
-      with_temporary_context(unknown_key: 42) do
-        expect(get('unknown_key')).to eq(42)
+      ctx.with_temporary_context(unknown_key: 42) do
+        expect(ctx.get('unknown_key')).to eq(42)
       end
     end
 
     it 'can override an existing variable' do
-      with_temporary_context(value: 'A completelly new value') do
-        expect(get('value')).to eq('A completelly new value')
+      ctx.with_temporary_context(value: 'A completelly new value') do
+        expect(ctx.get('value')).to eq('A completelly new value')
       end
     end
 
     it 'provides mutable variables (well, variables ...)' do
-      with_temporary_context(unknown_key: 42) do
-        expect(get('unknown_key')).to eq(42)
-        add_item('unknown_key', 56)
-        expect(get('unknown_key')).to eq(56)
+      ctx.with_temporary_context(unknown_key: 42) do
+        expect(ctx.get('unknown_key')).to eq(42)
+        ctx.add_item('unknown_key', 56)
+        expect(ctx.get('unknown_key')).to eq(56)
       end
     end
 
     it 'after the block, existing variables are restored' do
-      with_temporary_context(value: 'A completelly new value') do
-        expect(get('value')).to eq('A completelly new value')
+      ctx.with_temporary_context(value: 'A completelly new value') do
+        expect(ctx.get('value')).to eq('A completelly new value')
       end
 
-      expect(get('value')).to eq('some value')
+      expect(ctx.get('value')).to eq('some value')
     end
 
     it 'after the block, the declared variables are not available anymore' do
-      with_temporary_context(unknown_key: 42) do
-        expect(get('unknown_key')).to eq(42)
+      ctx.with_temporary_context(unknown_key: 42) do
+        expect(ctx.get('unknown_key')).to eq(42)
       end
 
-      expect(get('unknown_key')).to be nil
+      expect(ctx.get('unknown_key')).to be nil
     end
 
     it 'returns the data executed by the block' do
-      expect( with_temporary_context(value: 'A completelly new value') { 12 } ).to eq(12)
+      expect( ctx.with_temporary_context(value: 'A completelly new value') { 12 } ).to eq(12)
     end
 
     context 'when data are stored in @data' do
-      before do
-        @data = {my_key: "With some value"}
-      end
+      let(:data) { {my_key: "With some value"} }
 
       it 'let them available after the block is executed' do
-        expect(get('my_key')).to eq('With some value')
+        expect(ctx.get('my_key')).to eq('With some value')
 
-        with_temporary_context(my_key: 12) do
-          expect(get('my_key')).to eq(12)
+        ctx.with_temporary_context(my_key: 12) do
+          expect(ctx.get('my_key')).to eq(12)
         end
 
-        expect(get('my_key')).to eq('With some value')
+        expect(ctx.get('my_key')).to eq('With some value')
       end
     end
   end

--- a/spec/ruby-handlebars/helpers/each_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/each_helper_spec.rb
@@ -9,6 +9,7 @@ require_relative '../../../lib/ruby-handlebars/helpers/each_helper'
 describe Handlebars::Helpers::EachHelper do
   let(:subject) { Handlebars::Helpers::EachHelper }
   let(:hbs) {Handlebars::Handlebars.new}
+  let(:ctx) {Handlebars::Context.new(hbs, {})}
 
   it_behaves_like "a registerable helper", "each"
 
@@ -18,7 +19,7 @@ describe Handlebars::Helpers::EachHelper do
     let(:values) { [Handlebars::Tree::String.new('a'), Handlebars::Tree::String.new('b'), Handlebars::Tree::String.new('c') ]}
 
     it 'applies the block on all values' do
-      subject.apply(hbs, values, block, else_block)
+      subject.apply(ctx, values, block, else_block)
 
       expect(block).to have_received(:fn).exactly(3).times
       expect(else_block).not_to have_received(:fn)
@@ -28,14 +29,14 @@ describe Handlebars::Helpers::EachHelper do
       let(:values) { nil }
 
       it 'uses the else_block if provided' do
-        subject.apply(hbs, values, block, else_block)
+        subject.apply(ctx, values, block, else_block)
 
         expect(block).not_to have_received(:fn)
         expect(else_block).to have_received(:fn).once
       end
 
       it 'returns nil if no else_block is provided' do
-        expect(subject.apply(hbs, values, block, nil)).to be nil
+        expect(subject.apply(ctx, values, block, nil)).to be nil
       end
     end
 
@@ -43,14 +44,14 @@ describe Handlebars::Helpers::EachHelper do
       let(:values) { [] }
 
       it 'uses the else_block if provided' do
-        subject.apply(hbs, values, block, else_block)
+        subject.apply(ctx, values, block, else_block)
 
         expect(block).not_to have_received(:fn)
         expect(else_block).to have_received(:fn).once
       end
 
       it 'returns nil if no else_block is provided' do
-        expect(subject.apply(hbs, values, block, nil)).to be nil
+        expect(subject.apply(ctx, values, block, nil)).to be nil
       end
     end
   end

--- a/spec/ruby-handlebars/helpers/helper_missing_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/helper_missing_helper_spec.rb
@@ -9,6 +9,7 @@ require_relative '../../../lib/ruby-handlebars/helpers/helper_missing_helper'
 describe Handlebars::Helpers::HelperMissingHelper do
   let(:subject) { Handlebars::Helpers::HelperMissingHelper }
   let(:hbs) { Handlebars::Handlebars.new }
+  let(:ctx) {Handlebars::Context.new(hbs, {})}
 
   it_behaves_like "a registerable helper", "helperMissing"
 
@@ -16,7 +17,7 @@ describe Handlebars::Helpers::HelperMissingHelper do
     let(:name) { "missing_helper" }
 
     it 'raises a Handlebars::UnknownHelper exception with the name given as a parameter' do
-      expect { subject.apply(hbs, name, nil, nil) }.to raise_exception(Handlebars::UnknownHelper, "Helper \"#{name}\" does not exist")
+      expect { subject.apply(ctx, name, nil, nil) }.to raise_exception(Handlebars::UnknownHelper, "Helper \"#{name}\" does not exist")
     end
   end
 

--- a/spec/ruby-handlebars/helpers/if_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/if_helper_spec.rb
@@ -8,6 +8,7 @@ require_relative '../../../lib/ruby-handlebars/helpers/if_helper'
 describe Handlebars::Helpers::IfHelper do
   let(:subject) { Handlebars::Helpers::IfHelper }
   let(:hbs) {Handlebars::Handlebars.new}
+  let(:ctx) {Handlebars::Context.new(hbs, {})}
 
   it_behaves_like "a registerable helper", "if"
 
@@ -28,7 +29,7 @@ describe Handlebars::Helpers::IfHelper do
       let(:else_block) { nil }
 
       it 'returns an empty-string' do
-        expect(subject.apply(hbs, params, block, else_block)).to eq("")
+        expect(subject.apply(ctx, params, block, else_block)).to eq("")
 
         expect(block).not_to have_received(:fn)
         expect(else_block).not_to have_received(:fn)

--- a/spec/ruby-handlebars/helpers/shared.rb
+++ b/spec/ruby-handlebars/helpers/shared.rb
@@ -36,7 +36,7 @@ shared_examples "a helper running the main block" do |title, params|
   include_context "shared apply helper"
 
   it "when condition is #{title}" do
-    subject.apply(hbs, params, block, else_block)
+    subject.apply(ctx, params, block, else_block)
 
     expect(block).to have_received(:fn).once
     expect(else_block).not_to have_received(:fn)
@@ -47,7 +47,7 @@ shared_examples "a helper running the else block" do |title, params|
   include_context "shared apply helper"
 
   it "when condition is #{title}" do
-    subject.apply(hbs, params, block, else_block)
+    subject.apply(ctx, params, block, else_block)
 
     expect(block).not_to have_received(:fn)
     expect(else_block).to have_received(:fn).once

--- a/spec/ruby-handlebars/helpers/unless_helper_spec.rb
+++ b/spec/ruby-handlebars/helpers/unless_helper_spec.rb
@@ -8,6 +8,7 @@ require_relative '../../../lib/ruby-handlebars/helpers/unless_helper'
 describe Handlebars::Helpers::UnlessHelper do
   let(:subject) { Handlebars::Helpers::UnlessHelper }
   let(:hbs) {Handlebars::Handlebars.new}
+  let(:ctx) {Handlebars::Context.new(hbs, {})}
 
   it_behaves_like "a registerable helper", "unless"
 
@@ -28,7 +29,7 @@ describe Handlebars::Helpers::UnlessHelper do
       let(:else_block) { nil }
 
       it 'returns an empty-string' do
-        expect(subject.apply(hbs, params, block, else_block)).to eq("")
+        expect(subject.apply(ctx, params, block, else_block)).to eq("")
 
         expect(block).not_to have_received(:fn)
         expect(else_block).not_to have_received(:fn)


### PR DESCRIPTION
This allows for parsing a handlebars template once, and then evaluating it multiple times in a clean context, potentially simultaneously.