### PR TITLE
Explicitly require the CGI gem

### DIFF
--- a/lib/ruby-handlebars/escapers/html_escaper.rb
+++ b/lib/ruby-handlebars/escapers/html_escaper.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 module Handlebars
   module Escapers
     class HTMLEscaper


### PR DESCRIPTION
This prevents uninitialized constant errors for environments where there isn't another gem already requiring CGI