### PR TITLE
Allow integers as parameters

### DIFF
--- a/lib/ruby-handlebars/parser.rb
+++ b/lib/ruby-handlebars/parser.rb
@@ -42,11 +42,13 @@ module Handlebars
     rule(:sq_string)   { match("'") >> match("[^']").repeat.maybe.as(:str_content) >> match("'") }
     rule(:dq_string)   { match('"') >> match('[^"]').repeat.maybe.as(:str_content) >> match('"') }
     rule(:string)      { sq_string | dq_string }
+    rule(:digit) { match('[0-9]') }
+    rule(:integer) { digit.repeat(1).as(:integer_content) }
 
     rule(:parameter)   {
       (as_kw >> space? >> pipe).absent? >>
       (
-        (path | string).as(:parameter_name) |
+        (integer | path | string).as(:parameter_name) |
         (str('(') >> space? >> identifier.as(:safe_helper_name) >> (space? >> parameters.as(:parameters)).maybe >> space? >> str(')'))
       )
     }

--- a/lib/ruby-handlebars/tree.rb
+++ b/lib/ruby-handlebars/tree.rb
@@ -34,6 +34,12 @@ module Handlebars
       end
     end
 
+    class Integer < TreeItem.new(:content)
+      def _eval(context)
+        return content.to_i
+      end
+    end
+
     class Parameter < TreeItem.new(:name)
       def _eval(context)
         if name.is_a?(Parslet::Slice)
@@ -105,6 +111,7 @@ module Handlebars
     rule(replaced_unsafe_item: simple(:item)) {Tree::EscapedReplacement.new(item)}
     rule(replaced_safe_item: simple(:item)) {Tree::Replacement.new(item)}
     rule(str_content: simple(:content)) {Tree::String.new(content)}
+    rule(integer_content: simple(:content)) {Tree::Integer.new(content)}
     rule(parameter_name: simple(:name)) {Tree::Parameter.new(name)}
 
     rule(
@@ -171,7 +178,7 @@ module Handlebars
     ) {
       Tree::AsHelper.new(name, parameters, as_parameters, block_items, else_block_items)
     }
-    
+
     rule(
       partial_name: simple(:partial_name),
       arguments: subtree(:arguments)

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -51,6 +51,11 @@ describe Handlebars::Handlebars do
       expect(evaluate('Hello {{first-name}}', double("first-name": 'world'))).to eq('Hello world')
     end
 
+    it 'handles integer parameters' do
+      hbs.register_helper(:add){|context, a, b| a + b}
+      expect(evaluate('The sum is: {{add base_value 9}}', double("base_value": 2))).to eq('The sum is: 11')
+    end
+
     context 'partials' do
       it 'simple' do
         hbs.register_partial('plic', "Plic")

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -155,6 +155,22 @@ describe Handlebars::Parser do
         })
       end
 
+      it 'with integer parameters' do
+        result = parser.parse('{{ add 5 192 }}')
+        expect(result).to eq({
+          block_items: [
+            {
+              unsafe_helper_name: "add",
+              parameters: [
+                {parameter_name: {integer_content:   '5'}},
+                {parameter_name: {integer_content: '192'}}
+              ]
+            }
+          ]
+        })
+
+      end
+
       it 'block' do
         expect(parser.parse('{{#capitalize}}plic{{/capitalize}}')).to eq({
           block_items: [


### PR DESCRIPTION
At the moment implementing structures like:
```
{{#if (gt a b)}}
A is greater than b
{{/if}}
```
is possible. However using numbers in the templates is not.
This would be something like:
```
{{#if (gt my_value 10000)}}
Wow! What a great value!
{{/if}}
```

Therefore integers (and future floats) should be able to pass as parameters.